### PR TITLE
Added option to strip carriage return when exporting eml files

### DIFF
--- a/src/chrome/content/mboximport/exportTools.js
+++ b/src/chrome/content/mboximport/exportTools.js
@@ -1166,6 +1166,11 @@ function saveMsgAsEML(msguri, file, append, uriArray, hdrArray, fileArray, imapF
 					data = this.emailtext.replace(/^(From (?:.*?)\r?\n)([\x21-\x7E]+: )/, "$2");
 
 					data = IETescapeBeginningFrom(data);
+
+					if (IETprefs.getBoolPref("extensions.importexporttoolsng.export.strip_carriage_return")) {
+						data = data.replace(/\r\n/g,"\n");
+					}
+
 					var clone = file.clone();
 					// The name is taken from the subject "corrected"
 					clone.append(sub + ".eml");

--- a/src/chrome/content/mboximport/mboximportOptions.js
+++ b/src/chrome/content/mboximport/mboximportOptions.js
@@ -69,6 +69,7 @@ function initMboxImportPanel() {
     document.getElementById("addtimeCheckbox").checked = IETprefs.getBoolPref("extensions.importexporttoolsng.export.filenames_addtime");
     document.getElementById("buildMSF").checked = IETprefs.getBoolPref("extensions.importexporttoolsng.import.build_mbox_index");
     document.getElementById("addNumber").checked = IETprefs.getBoolPref("extensions.importexporttoolsng.import.name_add_number");
+    document.getElementById("stripCR").checked = IETprefs.getBoolPref("extensions.importexporttoolsng.export.strip_carriage_return");
 
     if (IETprefs.getIntPref("extensions.importexporttoolsng.exportEML.filename_format") === 2)
         document.getElementById("customizeFilenames").checked = true;
@@ -288,6 +289,7 @@ function saveMboxImportPrefs() {
     IETprefs.setBoolPref("extensions.importexporttoolsng.export.filenames_addtime", document.getElementById("addtimeCheckbox").checked);
     IETprefs.setBoolPref("extensions.importexporttoolsng.import.build_mbox_index", document.getElementById("buildMSF").checked);
     IETprefs.setBoolPref("extensions.importexporttoolsng.import.name_add_number", document.getElementById("addNumber").checked);
+    IETprefs.setBoolPref("extensions.importexporttoolsng.export.strip_carriage_return", document.getElementById("stripCR").checked);
 
     if (document.getElementById("customizeFilenames").checked)
         IETprefs.setIntPref("extensions.importexporttoolsng.exportEML.filename_format", 2);

--- a/src/chrome/content/mboximport/mboximportOptions.xhtml
+++ b/src/chrome/content/mboximport/mboximportOptions.xhtml
@@ -51,6 +51,9 @@
 						<hbox align="center">
 							<checkbox id="addNumber" label="&addNumber.label;" />
 						</hbox>
+						<hbox align="center">
+							<checkbox id="stripCR" label="&stripCR.label;" />
+						</hbox>
 						<hbox align="center" style="padding-left: 4px">
 							<label value="&csvSep;" />
 							<html:input id="csvSep" size="1" maxlength="1" />

--- a/src/chrome/locale/ca/mboximport/mboximport.dtd
+++ b/src/chrome/locale/ca/mboximport/mboximport.dtd
@@ -121,3 +121,5 @@
 <!ENTITY attachmentFolders "Carpetes adjuntes">
 <!ENTITY inlineAttachmentsFolders "Carpetes de fitxers adjunts en línia">
 <!ENTITY cutPathLen "Retalla la longitud del camí del fitxer a 256 caràcters">
+
+<!ENTITY stripCR.label "Strip carriage return when exporting eml files">

--- a/src/chrome/locale/da/mboximport/mboximport.dtd
+++ b/src/chrome/locale/da/mboximport/mboximport.dtd
@@ -121,3 +121,5 @@
 <!ENTITY attachmentFolders "Vedhæftede mapper">
 <!ENTITY inlineAttachmentsFolders "Inline vedhæftede mapper">
 <!ENTITY cutPathLen "Klip filstilængden til 256 tegn">
+
+<!ENTITY stripCR.label "Strip carriage return when exporting eml files">

--- a/src/chrome/locale/de/mboximport/mboximport.dtd
+++ b/src/chrome/locale/de/mboximport/mboximport.dtd
@@ -122,3 +122,5 @@
 <!ENTITY attachmentFolders "Anhangsordner">
 <!ENTITY inlineAttachmentsFolders "Inline-Anhangsordner">
 <!ENTITY cutPathLen "Dateipfadlänge auf 256 Zeichen reduzieren">
+
+<!ENTITY stripCR.label "Strip carriage return when exporting eml files">

--- a/src/chrome/locale/el/mboximport/mboximport.dtd
+++ b/src/chrome/locale/el/mboximport/mboximport.dtd
@@ -119,3 +119,5 @@
 <!ENTITY attachmentFolders "Φάκελοι συνημμένων">
 <!ENTITY inlineAttachmentsFolders "Ενσωματωμένοι φάκελοι συνημμένων">
 <!ENTITY cutPathLen "Κόψτε το μήκος της διαδρομής του αρχείου σε 256 χαρακτήρες">
+
+<!ENTITY stripCR.label "Strip carriage return when exporting eml files">

--- a/src/chrome/locale/en-US/mboximport/mboximport.dtd
+++ b/src/chrome/locale/en-US/mboximport/mboximport.dtd
@@ -123,3 +123,5 @@
 <!ENTITY attachmentFolders "Attachment Folders">
 <!ENTITY inlineAttachmentsFolders "Inline Attachments Folders">
 <!ENTITY cutPathLen "Cut file path length to 256 characters">
+
+<!ENTITY stripCR.label "Strip carriage return when exporting eml files">

--- a/src/chrome/locale/es-ES/mboximport/mboximport.dtd
+++ b/src/chrome/locale/es-ES/mboximport/mboximport.dtd
@@ -121,3 +121,5 @@
 <!ENTITY attachmentFolders "Carpetas de archivos adjuntos">
 <!ENTITY inlineAttachmentsFolders "Carpetas de archivos adjuntos en línea">
 <!ENTITY cutPathLen "Cortar la longitud de la ruta del archivo a 256 caracteres">
+
+<!ENTITY stripCR.label "Strip carriage return when exporting eml files">

--- a/src/chrome/locale/fr/mboximport/mboximport.dtd
+++ b/src/chrome/locale/fr/mboximport/mboximport.dtd
@@ -121,3 +121,5 @@
 <!ENTITY attachmentFolders "Dossiers de pièces jointes">
 <!ENTITY inlineAttachmentsFolders "Dossiers de pièces jointes en ligne">
 <!ENTITY cutPathLen "Coupez la longueur du chemin d&#39;accès au fichier à 256 caractères">
+
+<!ENTITY stripCR.label "Strip carriage return when exporting eml files">

--- a/src/chrome/locale/gl-ES/mboximport/mboximport.dtd
+++ b/src/chrome/locale/gl-ES/mboximport/mboximport.dtd
@@ -121,3 +121,5 @@
 <!ENTITY attachmentFolders "Cartafoles adxuntos">
 <!ENTITY inlineAttachmentsFolders "Cartafoles de anexos en liña">
 <!ENTITY cutPathLen "Cortar a lonxitude da ruta do ficheiro a 256 caracteres">
+
+<!ENTITY stripCR.label "Strip carriage return when exporting eml files">

--- a/src/chrome/locale/hu-HU/mboximport/mboximport.dtd
+++ b/src/chrome/locale/hu-HU/mboximport/mboximport.dtd
@@ -122,3 +122,5 @@
 <!ENTITY attachmentFolders "Mellékletek mappák">
 <!ENTITY inlineAttachmentsFolders "Beépített mellékletek mappái">
 <!ENTITY cutPathLen "Vágja le a fájl elérési útját 256 karakterre">
+
+<!ENTITY stripCR.label "Strip carriage return when exporting eml files">

--- a/src/chrome/locale/hy-AM/mboximport/mboximport.dtd
+++ b/src/chrome/locale/hy-AM/mboximport/mboximport.dtd
@@ -121,3 +121,5 @@
 <!ENTITY attachmentFolders "Հավելվածի թղթապանակներ">
 <!ENTITY inlineAttachmentsFolders "Ներդիր հավելվածների թղթապանակներ">
 <!ENTITY cutPathLen "Կտրեք ֆայլի ուղու երկարությունը մինչև 256 նիշ">
+
+<!ENTITY stripCR.label "Strip carriage return when exporting eml files">

--- a/src/chrome/locale/it/mboximport/mboximport.dtd
+++ b/src/chrome/locale/it/mboximport/mboximport.dtd
@@ -121,3 +121,5 @@
 <!ENTITY attachmentFolders "Cartelle allegati">
 <!ENTITY inlineAttachmentsFolders "Cartelle allegati in linea">
 <!ENTITY cutPathLen "Riduci la lunghezza del percorso del file a 256 caratteri">
+
+<!ENTITY stripCR.label "Strip carriage return when exporting eml files">

--- a/src/chrome/locale/ja/mboximport/mboximport.dtd
+++ b/src/chrome/locale/ja/mboximport/mboximport.dtd
@@ -121,3 +121,5 @@
 <!ENTITY attachmentFolders "添付ファイルフォルダー">
 <!ENTITY inlineAttachmentsFolders "インライン添付ファイルフォルダー">
 <!ENTITY cutPathLen "ファイルパスの長さを 256 文字にカット">
+
+<!ENTITY stripCR.label "Strip carriage return when exporting eml files">

--- a/src/chrome/locale/ko-KR/mboximport/mboximport.dtd
+++ b/src/chrome/locale/ko-KR/mboximport/mboximport.dtd
@@ -121,3 +121,5 @@
 <!ENTITY attachmentFolders "첨부파일">
 <!ENTITY inlineAttachmentsFolders "인라인 첨부 파일 폴더">
 <!ENTITY cutPathLen "파일 경로 길이를 256자로 자릅니다.">
+
+<!ENTITY stripCR.label "Strip carriage return when exporting eml files">

--- a/src/chrome/locale/nl/mboximport/mboximport.dtd
+++ b/src/chrome/locale/nl/mboximport/mboximport.dtd
@@ -121,3 +121,5 @@
 <!ENTITY attachmentFolders "Bijlagemappen">
 <!ENTITY inlineAttachmentsFolders "Inline bijlagenmappen">
 <!ENTITY cutPathLen "Snijd de lengte van het bestandspad in tot 256 tekens">
+
+<!ENTITY stripCR.label "Strip carriage return when exporting eml files">

--- a/src/chrome/locale/pl/mboximport/mboximport.dtd
+++ b/src/chrome/locale/pl/mboximport/mboximport.dtd
@@ -121,3 +121,5 @@
 <!ENTITY attachmentFolders "Foldery załączników">
 <!ENTITY inlineAttachmentsFolders "Wbudowane foldery załączników">
 <!ENTITY cutPathLen "Skróć długość ścieżki pliku do 256 znaków">
+
+<!ENTITY stripCR.label "Strip carriage return when exporting eml files">

--- a/src/chrome/locale/pt-PT/mboximport/mboximport.dtd
+++ b/src/chrome/locale/pt-PT/mboximport/mboximport.dtd
@@ -121,3 +121,5 @@
 <!ENTITY attachmentFolders "Pastas de anexos">
 <!ENTITY inlineAttachmentsFolders "Pastas de Anexos Inline">
 <!ENTITY cutPathLen "Corte o comprimento do caminho do arquivo para 256 caracteres">
+
+<!ENTITY stripCR.label "Strip carriage return when exporting eml files">

--- a/src/chrome/locale/ru/mboximport/mboximport.dtd
+++ b/src/chrome/locale/ru/mboximport/mboximport.dtd
@@ -122,3 +122,5 @@
 <!ENTITY attachmentFolders "Папки вложений">
 <!ENTITY inlineAttachmentsFolders "Встроенные папки вложений">
 <!ENTITY cutPathLen "Сократите длину пути к файлу до 256 символов.">
+
+<!ENTITY stripCR.label "Strip carriage return when exporting eml files">

--- a/src/chrome/locale/sk-SK/mboximport/mboximport.dtd
+++ b/src/chrome/locale/sk-SK/mboximport/mboximport.dtd
@@ -121,3 +121,5 @@
 <!ENTITY attachmentFolders "Priečinky príloh">
 <!ENTITY inlineAttachmentsFolders "Vložené priečinky príloh">
 <!ENTITY cutPathLen "Znížte dĺžku cesty k súboru na 256 znakov">
+
+<!ENTITY stripCR.label "Strip carriage return when exporting eml files">

--- a/src/chrome/locale/sl-SI/mboximport/mboximport.dtd
+++ b/src/chrome/locale/sl-SI/mboximport/mboximport.dtd
@@ -121,3 +121,5 @@
 <!ENTITY attachmentFolders "Mape s priponkami">
 <!ENTITY inlineAttachmentsFolders "Vgrajene mape s prilogami">
 <!ENTITY cutPathLen "Zmanjšajte dolžino poti do datoteke na 256 znakov">
+
+<!ENTITY stripCR.label "Strip carriage return when exporting eml files">

--- a/src/chrome/locale/sv-SE/mboximport/mboximport.dtd
+++ b/src/chrome/locale/sv-SE/mboximport/mboximport.dtd
@@ -121,3 +121,5 @@
 <!ENTITY attachmentFolders "Bifogade mappar">
 <!ENTITY inlineAttachmentsFolders "Inline bifogade mappar">
 <!ENTITY cutPathLen "Skär filsökvägen till 256 tecken">
+
+<!ENTITY stripCR.label "Strip carriage return when exporting eml files">

--- a/src/chrome/locale/zh-CN/mboximport/mboximport.dtd
+++ b/src/chrome/locale/zh-CN/mboximport/mboximport.dtd
@@ -121,3 +121,5 @@
 <!ENTITY attachmentFolders "附件文件夹">
 <!ENTITY inlineAttachmentsFolders "内联附件文件夹">
 <!ENTITY cutPathLen "将文件路径长度缩短为 256 个字符">
+
+<!ENTITY stripCR.label "Strip carriage return when exporting eml files">

--- a/src/defaults/preferences/prefs.js
+++ b/src/defaults/preferences/prefs.js
@@ -60,3 +60,4 @@ pref("extensions.importexporttoolsng.experimental.hot_keys", "");
 pref("extensions.importexporttoolsng.experimental.index_short1", false);
 pref("extensions.importexporttoolsng.experimental.printPDF.use_global_preferences", true);
 pref("extensions.importexporttoolsng.experimental.csv.account_folder_col", false);
+pref("extensions.importexporttoolsng.export.strip_carriage_return", false);


### PR DESCRIPTION
Currently, eml formatted files are exported with DOS (CRLF) line endings, as opposed to Unix (LF) line endings.

I added an option to strip CR (carriage return) when exporting eml files so that the resulting files can be viewed with QuickLook on macOS. Note that Apple's own Mail.app also exports eml files with just LF.

The added option is off by default, and can be enabled in the "Misc" tab of extension's options panel. Localizations will need to be updated for the string that is displayed; currently it will display an English string for all localizations.