### PR TITLE
Handle empty fullSubject in ExportMessages

### DIFF
--- a/src/api/ExportMessages/implementation.js
+++ b/src/api/ExportMessages/implementation.js
@@ -75,6 +75,11 @@ var ExportMessages = class extends ExtensionCommon.ExtensionAPI {
             }
             if (hdrItem == "fullSubject") {
               returnItems.fullSubject = msgHdr.mime2DecodedSubject;
+
+              if (!returnItems.fullSubject || !returnItems.fullSubject.trim()) {
+                returnItems.fullSubject = "No Subject";
+              }
+              
               if (msgHdr.flags & 0x0010) {
                 returnItems.fullSubject = "Re: " + returnItems.fullSubject;
               }


### PR DESCRIPTION
Set default subject to 'No Subject' if empty or whitespace. Now that messages without a subject are exported as HTML, they are clickable inside index.html. Unfortunately, this solution is hardcoded in English.